### PR TITLE
Fix data loader init and avg_score logic

### DIFF
--- a/audit_tool/dashboard/components/data_loader.py
+++ b/audit_tool/dashboard/components/data_loader.py
@@ -17,7 +17,7 @@ class BrandHealthDataLoader:
     """Enhanced data loader with proper type handling and derived metrics"""
     
     def __init__(self, audit_outputs_dir: str = "audit_outputs"):
-        self.audit_outputs_dir = Path("audit_outputs")
+        self.audit_outputs_dir = Path(audit_outputs_dir)
         self.unified_data_dir = Path("audit_data")
         
     def safe_sort_unique(self, series):
@@ -43,8 +43,8 @@ class BrandHealthDataLoader:
                         df['avg_score'] = df['final_score']
                     elif 'raw_score' in df.columns:
                         df['avg_score'] = df['raw_score']
-                    elif 'raw_score' in df.columns:
-                        df['avg_score'] = df['raw_score']
+                    else:
+                        df['avg_score'] = pd.NA
                 
                 return df
             


### PR DESCRIPTION
## Summary
- use provided path for data loader init
- correct avg_score fallthrough logic

## Testing
- `python audit_tool/tests/test_audit_tool.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_685e4e16d4f48324a7b048a2940c3065