### PR TITLE
Implement new parsers and helpers

### DIFF
--- a/audit_tool/ai_interface.py
+++ b/audit_tool/ai_interface.py
@@ -20,6 +20,7 @@ import json
 import logging
 import requests
 from typing import Dict, List, Any, Optional, Union
+from pathlib import Path
 
 from .methodology_parser import MethodologyParser
 
@@ -50,6 +51,24 @@ class AIInterface:
             logger.warning("Anthropic API key not found in environment variables")
         elif model_provider == "openai" and not self.openai_api_key:
             logger.warning("OpenAI API key not found in environment variables")
+
+    def _load_prompt_template(self, name: str) -> str:
+        """Load a prompt template from the templates directory."""
+        templates_dir = Path(__file__).parent / "templates"
+        for ext in [".md", ".j2", ".txt"]:
+            path = templates_dir / f"{name}{ext}"
+            if path.exists():
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read()
+        raise FileNotFoundError(f"Prompt template not found: {name}")
+
+    def _get_system_message(self, name: str) -> str:
+        """Return a default system prompt for a template name."""
+        defaults = {
+            "narrative_analysis": "You are a brand audit expert analyzing narrative quality and brand alignment.",
+            "scorecard": "You are a brand audit expert analyzing digital content.",
+        }
+        return defaults.get(name, "You are a brand audit expert analyzing digital content.")
     
     def generate_hygiene_scorecard(self, url: str, page_content: str, persona_content: str, methodology: MethodologyParser) -> str:
         """

--- a/audit_tool/methodology_parser.py
+++ b/audit_tool/methodology_parser.py
@@ -19,8 +19,18 @@ import yaml
 import logging
 from typing import Dict, List, Tuple, Any, Optional
 from pathlib import Path
+from dataclasses import dataclass
 
 from .tier_classifier import TierClassifier
+
+
+@dataclass
+class ParsedMethodology:
+    """Simple container for parsed methodology sections."""
+
+    metadata: Dict[str, Any]
+    tiers: Dict[str, Any]
+    offsite_channels: Dict[str, Any]
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +47,15 @@ class MethodologyParser:
         self.config_path = config_path or os.path.join("audit_tool", "config", "methodology.yaml")
         self.config = self._load_config()
         self.tier_classifier = TierClassifier(self.config)
-        
+
         logger.info(f"Methodology parser initialized with config: {self.config_path}")
+
+    def parse(self) -> ParsedMethodology:
+        """Parse the loaded YAML into a structured object."""
+        metadata = self.config.get("metadata", {})
+        tiers = self.config.get("classification", {}).get("onsite", {})
+        offsite = self.config.get("classification", {}).get("offsite", {})
+        return ParsedMethodology(metadata=metadata, tiers=tiers, offsite_channels=offsite)
     
     def _load_config(self) -> Dict[str, Any]:
         """

--- a/audit_tool/persona_parser.py
+++ b/audit_tool/persona_parser.py
@@ -59,10 +59,14 @@ class Persona:
 
 class PersonaParser:
     """Parses persona information from markdown files."""
-    
+
     def __init__(self):
         """Initialize the persona parser."""
         logger.info("Persona parser initialized")
+
+    def extract_attributes(self, file_path: str) -> Persona:
+        """Wrapper for backward compatibility."""
+        return self.extract_attributes_from_file(file_path)
     
     def extract_attributes_from_file(self, file_path: str) -> Persona:
         """

--- a/audit_tool/templates/narrative_analysis.md
+++ b/audit_tool/templates/narrative_analysis.md
@@ -1,0 +1,3 @@
+# Narrative Analysis for {persona_name}
+
+As the {persona_role} reviewing this page, analyse its narrative clarity, tone, and brand alignment. Summarise how effectively the content addresses key priorities and suggest improvements in 3-5 bullet points.


### PR DESCRIPTION
## Summary
- add dataclass `ParsedMethodology` and parser method
- expose wrapper `extract_attributes`
- load prompt templates and system messages in AI interface
- provide helper `run_audit` wrapper
- include simple narrative analysis template

## Testing
- `python audit_tool/tests/test_audit_tool.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_685e53a9b0d8832486ca5875f2d7ea52