### PR TITLE
Add Node script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,17 @@ streamlit run dashboard/streamlit_dashboard.py --server.runOnSave true
 ./launch_dashboard.sh --help  # Shows available options
 ```
 
+## 🟢 Node Example
+
+This repository now includes a small Node.js script located in `node_scripts/`.
+You can run it to verify Node is configured correctly:
+
+```bash
+cd node_scripts
+npm install
+npm run hello
+```
+
 ## 📄 License
 
 This project is proprietary and confidential. All rights reserved.

--- a/node_scripts/hello.js
+++ b/node_scripts/hello.js
@@ -1,0 +1,2 @@
+import chalk from 'chalk';
+console.log(chalk.green('Hello from Sopra Steria Node script!'));

--- a/node_scripts/package-lock.json
+++ b/node_scripts/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "node_scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node_scripts",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^5.4.1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    }
+  }
+}

--- a/node_scripts/package.json
+++ b/node_scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "node_scripts",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "hello": "node hello.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "chalk": "^5.4.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple Node script using `chalk`
- document how to run the example in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Expected None, but test returned True/False)*


------
https://chatgpt.com/codex/tasks/task_b_685e67a5c3b88324be6dad7dc5fb090b