### PR TITLE
Add version helper and CLI flag

### DIFF
--- a/audit_tool/__init__.py
+++ b/audit_tool/__init__.py
@@ -20,6 +20,11 @@ __author__ = "Sopra Steria Digital Experience Team"
 __email__ = "digital.experience@soprasteria.com"
 __license__ = "Proprietary"
 
+# Public helper
+def get_version() -> str:
+    """Return the current package version."""
+    return __version__
+
 # Import key components for easier access
 from .ai_interface import AIInterface
 from .methodology_parser import MethodologyParser

--- a/audit_tool/main.py
+++ b/audit_tool/main.py
@@ -38,6 +38,7 @@ from .methodology_parser import MethodologyParser
 from .persona_parser import PersonaParser
 from .multi_persona_packager import MultiPersonaPackager
 from .strategic_summary_generator import StrategicSummaryGenerator
+from . import __version__
 
 # Configure logging
 logging.basicConfig(
@@ -289,8 +290,13 @@ def main():
     parser.add_argument('--all-personas', action='store_true', help='Run audit with all personas')
     parser.add_argument('--config', type=str, help='Path to configuration file')
     parser.add_argument('--output-dir', type=str, help='Output directory')
+    parser.add_argument('--version', action='store_true', help='Show version and exit')
     
     args = parser.parse_args()
+
+    if args.version:
+        print(f"Sopra Steria Brand Audit Tool {__version__}")
+        return
     
     # Initialize the tool
     tool = BrandAuditTool(args.config)


### PR DESCRIPTION
## Summary
- add `get_version` helper in `audit_tool/__init__.py`
- expose `--version` flag in `audit_tool/main.py`

## Testing
- `python audit_tool/tests/test_audit_tool.py`
- `python -c "from audit_tool.ai_interface import AIInterface; print('AI Interface OK')"`
- `python -c "from audit_tool.main import run_audit; print('Main module OK')"`


------
https://chatgpt.com/codex/tasks/task_b_685e72fbc338832483c2cab431c88573