### PR TITLE
Continue Node refactor with Swagger docs

### DIFF
--- a/NODE_REFACTOR_LOG.md
+++ b/NODE_REFACTOR_LOG.md
@@ -7,15 +7,15 @@ This file tracks the ongoing migration from the Streamlit dashboard to the Node.
 - CI workflow running both `pytest` and `pnpm test`
 - Express API with `/api/hello` endpoint and basic tests
 - Vite React app scaffold
+- Stub routes for `/datasets`, `/pages`, `/recommendations`
+- Swagger UI documentation
+- Additional API tests (including docs endpoint)
 
 ## In Progress
-- Stub routes for `/datasets`, `/pages`, `/recommendations`
-- Swagger UI documentation setup
-- Additional API tests
-
-## Todo
 - Bridge Python functionality via FastAPI or shell wrappers
 - Recreate Streamlit visuals using React components
+
+## Todo
 - Add authentication and environment-driven configuration
 - Production hardening (Docker, CI/CD, load testing)
 - Deprecate Streamlit dashboard once feature complete

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -11,23 +11,93 @@ const swaggerSpec = swaggerJsdoc({
     openapi: '3.0.0',
     info: { title: 'Sopra Steria Audit API', version: '0.1.0' }
   },
-  apis: []
+  apis: ['./src/**/*.js']
 });
 
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
+/**
+ * @openapi
+ * /api/hello:
+ *   get:
+ *     summary: Returns a friendly greeting
+ *     responses:
+ *       200:
+ *         description: Greeting message
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ */
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from API' });
 });
 
+/**
+ * @openapi
+ * /api/datasets:
+ *   get:
+ *     summary: List available datasets
+ *     responses:
+ *       200:
+ *         description: Array of datasets
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 datasets:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ */
 app.get('/api/datasets', (_req, res) => {
   res.json({ datasets: [] });
 });
 
+/**
+ * @openapi
+ * /api/pages:
+ *   get:
+ *     summary: List available pages
+ *     responses:
+ *       200:
+ *         description: Array of pages
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 pages:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ */
 app.get('/api/pages', (_req, res) => {
   res.json({ pages: [] });
 });
 
+/**
+ * @openapi
+ * /api/recommendations:
+ *   get:
+ *     summary: List content recommendations
+ *     responses:
+ *       200:
+ *         description: Array of recommendations
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 recommendations:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ */
 app.get('/api/recommendations', (_req, res) => {
   res.json({ recommendations: [] });
 });

--- a/api/test/routes.test.js
+++ b/api/test/routes.test.js
@@ -25,3 +25,11 @@ describe('GET /api/recommendations', () => {
     expect(res.body).toEqual({ recommendations: [] });
   });
 });
+
+describe('GET /api/docs', () => {
+  it('serves Swagger UI', async () => {
+    const res = await request(app).get('/api/docs/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Swagger UI');
+  });
+});


### PR DESCRIPTION
## Summary
- document API routes using Swagger JSDoc comments
- expose docs endpoint in tests
- update refactor progress log

## Testing
- `pnpm test`
- `pytest -q` *(fails: test_yaml_configuration, test_persona_parsing, test_scraper, test_ai_interface, test_full_audit_pipeline)*

------
https://chatgpt.com/codex/tasks/task_b_686ae41f2c708324948fcc2aaf936f23