### PR TITLE
Update Node refactor docs and dependencies

### DIFF
--- a/NODE_REFACTOR_LOG.md
+++ b/NODE_REFACTOR_LOG.md
@@ -10,9 +10,11 @@ This file tracks the ongoing migration from the Streamlit dashboard to the Node.
 - Stub routes for `/datasets`, `/pages`, `/recommendations`
 - Swagger UI documentation
 - Additional API tests (including docs endpoint)
+- Added axios dependency for future FastAPI integration
 
 ## In Progress
 - Bridge Python functionality via FastAPI or shell wrappers
+- Begin migrating dataset list page to React
 - Recreate Streamlit visuals using React components
 
 ## Todo

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
     "cors": "^2.8.5",
     "express": "^5.0.2",
     "swagger-jsdoc": "6.2.8",
-    "swagger-ui-express": "5.0.1"
+    "swagger-ui-express": "5.0.1",
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "supertest": "^7.1.1",

--- a/node_refactor.md
+++ b/node_refactor.md
@@ -34,6 +34,7 @@ Migrate the current Streamlit-based Python dashboard to a modern web stack: **No
 1. Merge current `dev` work to `codex` (done).
 2. Create the `/api` and `/web` folders with minimal `package.json`.
 3. Set up CI job that runs both `pytest` **and** `npm test`.
+4. Expose Python audit functions via FastAPI service.
+5. Install `axios` in the API to call the FastAPI endpoints.
+6. Begin migrating the dataset list page to React.
 
----
-For detailed task breakdowns use the project board **"Node Refactor"**. 


### PR DESCRIPTION
## Summary
- document new immediate next steps for the Node.js refactor
- log progress including axios addition and React page migration
- add axios dependency in API package

## Testing
- `pnpm -r test --if-present`
- `python audit_tool/tests/test_audit_tool.py`


------
https://chatgpt.com/codex/tasks/task_b_686ae6491dc88324bb56709f090cf096