### PR TITLE
Add FastAPI service and connect Node proxy

### DIFF
--- a/NODE_REFACTOR_LOG.md
+++ b/NODE_REFACTOR_LOG.md
@@ -13,12 +13,12 @@ This file tracks the ongoing migration from the Streamlit dashboard to the Node.
 - Added axios dependency for future FastAPI integration
 
 ## In Progress
-- Bridge Python functionality via FastAPI or shell wrappers
+- Bridge Python functionality via FastAPI or shell wrappers *(FastAPI service created)*
 - Begin migrating dataset list page to React
 - Recreate Streamlit visuals using React components
 
 ## Next Tasks
-- Implement Express proxy routes to call the FastAPI service for datasets and pages
+- Implement Express proxy routes to call the FastAPI service for datasets and pages *(completed)*
 - Use React Query to fetch dataset data in the new React page
 - Add integration tests covering the Express → FastAPI call chain
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ pnpm start
 # Test the API endpoint
 curl http://localhost:3000/api/hello
 # {"message":"Hello from API"}
+
+# To launch the Python FastAPI service
+cd fastapi_service
+python server.py
+
+# Test the FastAPI endpoint
+curl http://localhost:8000/hello
+# {"message":"Hello from FastAPI"}
 ```
 
 ## 🎯 Project Overview

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
+import axios from 'axios';
 
 const app = express();
 app.use(cors());
@@ -54,8 +55,23 @@ app.get('/api/hello', (_req, res) => {
  *                   items:
  *                     type: object
  */
-app.get('/api/datasets', (_req, res) => {
-  res.json({ datasets: [] });
+app.get('/api/datasets', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/datasets');
+    res.json(response.data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch datasets' });
+  }
+});
+
+app.get('/api/datasets/:name', async (req, res) => {
+  try {
+    const { name } = req.params;
+    const response = await axios.get(`http://localhost:8000/datasets/${name}`);
+    res.json(response.data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch dataset' });
+  }
 });
 
 /**
@@ -76,8 +92,13 @@ app.get('/api/datasets', (_req, res) => {
  *                   items:
  *                     type: object
  */
-app.get('/api/pages', (_req, res) => {
-  res.json({ pages: [] });
+app.get('/api/pages', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/datasets/pages');
+    res.json({ pages: response.data });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch pages' });
+  }
 });
 
 /**
@@ -98,8 +119,13 @@ app.get('/api/pages', (_req, res) => {
  *                   items:
  *                     type: object
  */
-app.get('/api/recommendations', (_req, res) => {
-  res.json({ recommendations: [] });
+app.get('/api/recommendations', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/datasets/recommendations');
+    res.json({ recommendations: response.data });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch recommendations' });
+  }
 });
 
 const port = process.env.PORT || 3000;

--- a/api/test/routes.test.js
+++ b/api/test/routes.test.js
@@ -1,28 +1,35 @@
 import request from 'supertest';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import app from '../src/index.js';
+import axios from 'axios';
 
 describe('GET /api/datasets', () => {
-  it('returns empty datasets array', async () => {
+  it('proxies dataset list from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: { datasets: ['pages'] } });
     const res = await request(app).get('/api/datasets');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ datasets: [] });
+    expect(res.body).toEqual({ datasets: ['pages'] });
+    vi.restoreAllMocks();
   });
 });
 
 describe('GET /api/pages', () => {
-  it('returns empty pages array', async () => {
+  it('proxies pages from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ id: 1 }] });
     const res = await request(app).get('/api/pages');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ pages: [] });
+    expect(res.body).toEqual({ pages: [{ id: 1 }] });
+    vi.restoreAllMocks();
   });
 });
 
 describe('GET /api/recommendations', () => {
-  it('returns empty recommendations array', async () => {
+  it('proxies recommendations from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ id: 1 }] });
     const res = await request(app).get('/api/recommendations');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ recommendations: [] });
+    expect(res.body).toEqual({ recommendations: [{ id: 1 }] });
+    vi.restoreAllMocks();
   });
 });
 

--- a/audit_tool/tests/test_audit_tool.py
+++ b/audit_tool/tests/test_audit_tool.py
@@ -28,11 +28,11 @@ def test_yaml_configuration():
         assert len(methodology.offsite_channels) == 3
         
         print("✅ YAML Configuration test passed")
-        return True
+        assert True
         
     except Exception as e:
         print(f"❌ YAML Configuration test failed: {e}")
-        return False
+        assert False
 
 def test_persona_parsing():
     """Test persona parsing functionality"""
@@ -54,11 +54,11 @@ def test_persona_parsing():
         assert len(persona.pain_points) > 0
         
         print("✅ Persona Parsing test passed")
-        return True
+        assert True
         
     except Exception as e:
         print(f"❌ Persona Parsing test failed: {e}")
-        return False
+        assert False
 
 def test_scraper():
     """Test web scraping functionality"""
@@ -78,11 +78,11 @@ def test_scraper():
         assert 'objective_findings' in page_data.__dict__
         
         print("✅ Web Scraper test passed")
-        return True
+        assert True
         
     except Exception as e:
         print(f"❌ Web Scraper test failed: {e}")
-        return False
+        assert False
 
 def test_ai_interface():
     """Test AI interface functionality"""
@@ -103,11 +103,11 @@ def test_ai_interface():
         assert len(system_msg) > 10
         
         print("✅ AI Interface test passed")
-        return True
+        assert True
         
     except Exception as e:
         print(f"❌ AI Interface test failed: {e}")
-        return False
+        assert False
 
 def test_full_audit_pipeline():
     """Test the complete audit pipeline"""
@@ -140,11 +140,11 @@ def test_full_audit_pipeline():
             assert len(output_files) >= 2  # At least hygiene and experience reports
             
         print("✅ Full Audit Pipeline test passed")
-        return True
+        assert True
         
     except Exception as e:
         print(f"❌ Full Audit Pipeline test failed: {e}")
-        return False
+        assert False
 
 def run_all_tests():
     """Run all tests"""

--- a/audit_tool/tests/test_fastapi_service.py
+++ b/audit_tool/tests/test_fastapi_service.py
@@ -1,0 +1,16 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi_service.main import app
+
+client = TestClient(app)
+
+def test_hello_endpoint():
+    resp = client.get('/hello')
+    assert resp.status_code == 200
+    assert resp.json() == {'message': 'Hello from FastAPI'}
+
+
+def test_datasets_endpoint():
+    resp = client.get('/datasets')
+    assert resp.status_code == 200
+    assert 'datasets' in resp.json()

--- a/fastapi_service/__init__.py
+++ b/fastapi_service/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/fastapi_service/main.py
+++ b/fastapi_service/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from audit_tool.dashboard.components.data_loader import BrandHealthDataLoader
+
+app = FastAPI(title="Sopra Steria Audit FastAPI")
+
+data_loader = BrandHealthDataLoader()
+
+@app.get("/hello")
+def read_root():
+    return {"message": "Hello from FastAPI"}
+
+@app.get("/datasets")
+def list_datasets():
+    datasets, _ = data_loader.load_all_data()
+    return {"datasets": list(datasets.keys())}
+
+@app.get("/datasets/{name}")
+def get_dataset(name: str):
+    datasets, _ = data_loader.load_all_data()
+    if name not in datasets:
+        return JSONResponse(status_code=404, content={"error": "Dataset not found"})
+    df = datasets[name]
+    return df.to_dict(orient="records")
+

--- a/fastapi_service/server.py
+++ b/fastapi_service/server.py
@@ -1,0 +1,5 @@
+import uvicorn
+from .main import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ pandas
 plotly
 requests
 PyYAML
+fastapi
+uvicorn

--- a/web/src/pages/DatasetList.tsx
+++ b/web/src/pages/DatasetList.tsx
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
 function DatasetList() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['datasets'],
     queryFn: async () => {
-      const res = await fetch('http://localhost:3000/api/datasets');
+      const res = await fetch(`${apiBase}/api/datasets`);
       if (!res.ok) throw new Error('Failed to load datasets');
       return res.json();
     },


### PR DESCRIPTION
## Summary
- implement FastAPI microservice to expose audit datasets
- proxy Express routes through axios to FastAPI
- update DatasetList page to use configurable API base
- fix Python tests and add FastAPI service tests
- document FastAPI service in README

## Testing
- `pnpm -r test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686b6b7624c48324955d1ce8e5b15a4f