### PR TITLE
Add recommendations React page

### DIFF
--- a/NODE_REFACTOR_LOG.md
+++ b/NODE_REFACTOR_LOG.md
@@ -23,12 +23,13 @@ This file tracks the ongoing migration from the Streamlit dashboard to the Node.
 - Integration tests covering the Express → FastAPI call chain
 - Integration tests verified passing on 2025-07-07
 - Added dataset detail page in React using @tanstack/react-table
+- Created recommendations page in React using React Table
 
 ## In Progress
 - Recreate Streamlit visuals using React components
+- Migrating additional dashboard pages to React
 
 ## Next Tasks
-- Begin migrating remaining dashboard pages to React
 - Add authentication and environment-driven configuration
 
 ## Todo

--- a/node_refactor.md
+++ b/node_refactor.md
@@ -50,7 +50,8 @@ Migrate the current Streamlit-based Python dashboard to a modern web stack: **No
 - [x] **Write integration tests for the new data flow.**
 - [x] **Verified integration tests passing.** (2025-07-07)
 - [x] **Create dataset detail page using React Table.**
+- [x] **Start migration of additional pages (added Recommendations page).**
 
 **⏳ Next Up**
-- Begin migrating remaining dashboard pages to React.
+- Continue migrating remaining dashboard pages to React.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Link } from 'react-router-dom'
 import DatasetList from './pages/DatasetList'
 import DatasetDetail from './pages/DatasetDetail'
 import PagesList from './pages/PagesList'
+import Recommendations from './pages/Recommendations'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
@@ -23,7 +24,8 @@ function App() {
       <nav>
         <Link to="/">Home</Link> |{' '}
         <Link to="/datasets">Datasets</Link> |{' '}
-        <Link to="/pages">Pages</Link>
+        <Link to="/pages">Pages</Link> |{' '}
+        <Link to="/recommendations">Recommendations</Link>
       </nav>
       <Routes>
         <Route
@@ -57,6 +59,7 @@ function App() {
         <Route path="/datasets" element={<DatasetList />} />
         <Route path="/datasets/:name" element={<DatasetDetail />} />
         <Route path="/pages" element={<PagesList />} />
+        <Route path="/recommendations" element={<Recommendations />} />
       </Routes>
     </>
   )

--- a/web/src/pages/Recommendations.tsx
+++ b/web/src/pages/Recommendations.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query'
+import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import React from 'react'
+
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+
+function Recommendations() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['recommendations'],
+    queryFn: async () => {
+      const res = await fetch(`${apiBase}/api/recommendations`)
+      if (!res.ok) throw new Error('Failed to load recommendations')
+      return res.json()
+    },
+  })
+
+  if (isLoading) return <p>Loading recommendations...</p>
+  if (error) return <p>Error loading recommendations</p>
+
+  const recs = Array.isArray(data?.recommendations) ? data.recommendations : []
+
+  const columns = React.useMemo<ColumnDef<any, any>[]>(() => {
+    if (recs.length === 0) return []
+    return Object.keys(recs[0]).map(key => ({ accessorKey: key, header: key }))
+  }, [recs])
+
+  const table = useReactTable({ data: recs, columns, getCoreRowModel: getCoreRowModel() })
+
+  return (
+    <div>
+      <h2>Recommendations</h2>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <th key={header.id}>{header.isPlaceholder ? null : header.column.columnDef.header as string}</th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id}>{cell.renderValue<string>()}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default Recommendations


### PR DESCRIPTION
## Summary
- create `Recommendations` page to display dataset recommendations
- link to new page and route in `App.tsx`
- document page migration progress

## Testing
- `pnpm -r test --if-present`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_686b94ec72508324baa69e6760d27aae