### PR TITLE
Add React Methodology page

### DIFF
--- a/NODE_REFACTOR_LOG.md
+++ b/NODE_REFACTOR_LOG.md
@@ -24,6 +24,7 @@ This file tracks the ongoing migration from the Streamlit dashboard to the Node.
 - Integration tests verified passing on 2025-07-07
 - Added dataset detail page in React using @tanstack/react-table
 - Created recommendations page in React using React Table
+- Added Methodology page in React fetching YAML via new API route
 
 ## In Progress
 - Recreate Streamlit visuals using React components

--- a/api/package.json
+++ b/api/package.json
@@ -11,11 +11,12 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "axios": "^1.6.0",
     "cors": "^2.8.5",
     "express": "^5.0.2",
+    "js-yaml": "^4.1.0",
     "swagger-jsdoc": "6.2.8",
-    "swagger-ui-express": "5.0.1",
-    "axios": "^1.6.0"
+    "swagger-ui-express": "5.0.1"
   },
   "devDependencies": {
     "supertest": "^7.1.1",

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -3,6 +3,10 @@ import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import axios from 'axios';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
 
 const app = express();
 app.use(cors());
@@ -125,6 +129,18 @@ app.get('/api/recommendations', async (_req, res) => {
     res.json({ recommendations: response.data });
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch recommendations' });
+  }
+});
+
+app.get('/api/methodology', async (_req, res) => {
+  try {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const filePath = path.join(__dirname, '..', '..', 'audit_tool', 'config', 'methodology.yaml');
+    const file = await readFile(filePath, 'utf8');
+    const data = yaml.load(file);
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load methodology' });
   }
 });
 

--- a/api/test/integration.test.js
+++ b/api/test/integration.test.js
@@ -15,7 +15,7 @@ beforeAll(async () => {
     stdio: 'ignore'
   });
   // wait briefly for the FastAPI server to start
-  await new Promise((res) => setTimeout(res, 2000));
+  await new Promise((res) => setTimeout(res, 3000));
 });
 
 afterAll(() => {
@@ -29,5 +29,11 @@ describe('Integration Express->FastAPI', () => {
     const res = await request(app).get('/api/datasets');
     expect(res.status).toBe(200);
     expect(res.body.datasets).toContain('master');
+  });
+
+  it('serves methodology data', async () => {
+    const res = await request(app).get('/api/methodology');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('calculation');
   });
 });

--- a/api/test/routes.test.js
+++ b/api/test/routes.test.js
@@ -2,6 +2,10 @@ import request from 'supertest';
 import { describe, it, expect, vi } from 'vitest';
 import app from '../src/index.js';
 import axios from 'axios';
+import * as fs from 'fs/promises';
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(() => Promise.resolve('calculation:\n  formula: TEST'))
+}));
 
 describe('GET /api/datasets', () => {
   it('proxies dataset list from FastAPI', async () => {
@@ -30,6 +34,14 @@ describe('GET /api/recommendations', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ recommendations: [{ id: 1 }] });
     vi.restoreAllMocks();
+  });
+});
+
+describe('GET /api/methodology', () => {
+  it('returns methodology yaml as json', async () => {
+    const res = await request(app).get('/api/methodology');
+    expect(res.status).toBe(200);
+    expect(res.body.calculation.formula).toBe('TEST');
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       express:
         specifier: ^5.0.2
         version: 5.1.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       swagger-jsdoc:
         specifier: 6.2.8
         version: 6.2.8(openapi-types@12.1.3)

--- a/web/src/pages/Methodology.tsx
+++ b/web/src/pages/Methodology.tsx
@@ -1,10 +1,40 @@
 import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 
 function Methodology() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['methodology'],
+    queryFn: async () => {
+      const res = await fetch(`${apiBase}/api/methodology`)
+      if (!res.ok) throw new Error('Failed to load methodology')
+      return res.json()
+    }
+  })
+
+  if (isLoading) return <p>Loading methodology...</p>
+  if (error) return <p>Error loading methodology</p>
+
+  const formula = data?.calculation?.formula
+  const descriptors = data?.scoring?.descriptors || {}
+
   return (
     <div>
       <h2>Methodology</h2>
-      <p>Page under construction. Refer to the Streamlit version for full details.</p>
+      {formula && (
+        <p>
+          <strong>Score Formula:</strong> {formula}
+        </p>
+      )}
+      <h3>Score Descriptors</h3>
+      <ul>
+        {Object.entries(descriptors).map(([range, details]: any) => (
+          <li key={range}>
+            {range}: {details.label} ({details.status})
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expose `/api/methodology` by reading the YAML config
- fetch methodology data in the Methodology React page
- test new API route and integration
- log progress in `NODE_REFACTOR_LOG.md`

## Testing
- `pytest -q`
- `pnpm -r test --if-present`


------
https://chatgpt.com/codex/tasks/task_b_686ba587b8ec8324b6822d7eeacf6462