### PR TITLE
Port implementation tracking page to React

### DIFF
--- a/NODE_REFACTOR_LOG.md
+++ b/NODE_REFACTOR_LOG.md
@@ -25,6 +25,7 @@ This file tracks the ongoing migration from the Streamlit dashboard to the Node.
 - Added dataset detail page in React using @tanstack/react-table
 - Created recommendations page in React using React Table
 - Added Methodology page in React fetching YAML via new API route
+- Migrated Implementation Tracking page to React using Recharts for progress visualization
 
 ## In Progress
 - **Page Migration:** The migration of the remaining dashboard pages from Streamlit to React is underway. For a detailed checklist of pages and the testing strategy, see the "Next Up" section in `node_refactor.md`.

--- a/node_refactor.md
+++ b/node_refactor.md
@@ -67,7 +67,7 @@ The foundational data flow is complete. The next major effort is to migrate the 
 *   [ ] **Persona Viewer** (`9_👤_Persona_Viewer.py`)
 *   [ ] **Visual Brand Hygiene** (`10_🎨_Visual_Brand_Hygiene.py`)
 *   [ ] **Persona Insights** (`2_👥_Persona_Insights.py`)
-*   [ ] **Implementation Tracking** (`12_📈_Implementation_Tracking.py`)
+*   [x] **Implementation Tracking** (`12_📈_Implementation_Tracking.py`)
 *   [ ] **Audit Reports** (`13_📄_Audit_Reports.py`)
 
 **Component & Testing Strategy:**

--- a/web/src/pages/ImplementationTracking.tsx
+++ b/web/src/pages/ImplementationTracking.tsx
@@ -1,10 +1,82 @@
 import React from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts'
+
+interface Item {
+  status: string
+  progress: number
+  team: string
+  name: string
+}
+
+const sampleData: Record<string, Omit<Item, 'name'>> = {
+  'Homepage Messaging': { status: 'completed', progress: 100, team: 'Marketing' },
+  'Navigation UX': { status: 'in_progress', progress: 65, team: 'UX Team' },
+  'Visual Brand Elements': { status: 'in_progress', progress: 30, team: 'Design' },
+  'Social Media Consistency': { status: 'not_started', progress: 0, team: 'Social' },
+  'Page Performance': { status: 'completed', progress: 100, team: 'Tech' }
+}
 
 function ImplementationTracking() {
+  const items: Item[] = Object.entries(sampleData).map(([name, d]) => ({
+    name,
+    ...d
+  }))
+
+  const totalItems = items.length
+  const completed = items.filter(i => i.status === 'completed').length
+  const inProgress = items.filter(i => i.status === 'in_progress').length
+  const avgProgress = items.reduce((sum, i) => sum + i.progress, 0) / totalItems
+  const completionRate = (completed / totalItems) * 100
+
   return (
     <div>
       <h2>Implementation Tracking</h2>
-      <p>Page under construction. Implementation progress tracking will be added.</p>
+      <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
+        <div>
+          <strong>{totalItems}</strong>
+          <div>Total Items</div>
+        </div>
+        <div>
+          <strong>{completionRate.toFixed(1)}%</strong>
+          <div>Completion Rate</div>
+        </div>
+        <div>
+          <strong>{avgProgress.toFixed(1)}%</strong>
+          <div>Avg Progress</div>
+        </div>
+        <div>
+          <strong>{inProgress}</strong>
+          <div>In Progress</div>
+        </div>
+      </div>
+
+      <BarChart width={600} height={300} data={items} style={{ marginBottom: '1rem' }}>
+        <XAxis dataKey="name" hide={true} />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="progress" fill="#3d4a6b" />
+      </BarChart>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Initiative</th>
+            <th>Status</th>
+            <th>Progress</th>
+            <th>Team</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(item => (
+            <tr key={item.name}>
+              <td>{item.name}</td>
+              <td>{item.status.replace('_', ' ')}</td>
+              <td>{item.progress}%</td>
+              <td>{item.team}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- port Implementation Tracking page from Streamlit to React
- mark Implementation Tracking page complete in the refactor plan
- log completion in the Node refactor progress log

## Testing
- `pnpm -r test --if-present` *(fails: Integration Express->FastAPI > proxies dataset list)*

------
https://chatgpt.com/codex/tasks/task_b_686bea7200388324b075813d530eaef3