### PR TITLE
Add executive summary endpoint and dashboard

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -166,6 +166,28 @@ app.get('/api/opportunities', async (req, res) => {
   }
 });
 
+/**
+ * @openapi
+ * /api/summary:
+ *   get:
+ *     summary: Executive summary metrics
+ *     responses:
+ *       200:
+ *         description: Summary object
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ */
+app.get('/api/summary', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/executive-summary');
+    res.json(response.data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch executive summary' });
+  }
+});
+
 app.get('/api/methodology', async (_req, res) => {
   try {
     const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/api/test/integration.test.js
+++ b/api/test/integration.test.js
@@ -43,4 +43,10 @@ describe('Integration Express->FastAPI', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('opportunities');
   });
+
+  it('returns executive summary', async () => {
+    const res = await request(app).get('/api/summary');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('brand_health');
+  });
 });

--- a/api/test/routes.test.js
+++ b/api/test/routes.test.js
@@ -47,6 +47,16 @@ describe('GET /api/opportunities', () => {
   });
 });
 
+describe('GET /api/summary', () => {
+  it('proxies summary from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: { brand_health: { raw_score: 8.2 } } });
+    const res = await request(app).get('/api/summary');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ brand_health: { raw_score: 8.2 } });
+    vi.restoreAllMocks();
+  });
+});
+
 describe('GET /api/methodology', () => {
   it('returns methodology yaml as json', async () => {
     const res = await request(app).get('/api/methodology');

--- a/audit_tool/tests/test_fastapi_service.py
+++ b/audit_tool/tests/test_fastapi_service.py
@@ -14,3 +14,9 @@ def test_datasets_endpoint():
     resp = client.get('/datasets')
     assert resp.status_code == 200
     assert 'datasets' in resp.json()
+
+
+def test_executive_summary_endpoint():
+    resp = client.get('/executive-summary')
+    assert resp.status_code == 200
+    assert 'brand_health' in resp.json()

--- a/fastapi_service/main.py
+++ b/fastapi_service/main.py
@@ -37,3 +37,15 @@ def get_opportunities(limit: int = 20):
     opportunities = metrics.get_top_opportunities(limit=limit)
     return {"opportunities": opportunities}
 
+
+@app.get("/executive-summary")
+def get_executive_summary():
+    """Return executive summary metrics"""
+    data_loader = BrandHealthDataLoader()
+    datasets, master_df = data_loader.load_all_data()
+    metrics = BrandHealthMetricsCalculator(
+        master_df, datasets.get("recommendations")
+    )
+    summary = metrics.generate_executive_summary()
+    return summary
+

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import PersonaViewer from './pages/PersonaViewer'
 import VisualBrandHygiene from './pages/VisualBrandHygiene'
 import ImplementationTracking from './pages/ImplementationTracking'
 import AuditReports from './pages/AuditReports'
+import ExecutiveDashboard from './pages/ExecutiveDashboard'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
@@ -35,6 +36,7 @@ function App() {
     <>
       <nav>
         <Link to="/">Home</Link> |{' '}
+        <Link to="/executive-dashboard">Executive Dashboard</Link> |{' '}
         <Link to="/datasets">Datasets</Link> |{' '}
         <Link to="/pages">Pages</Link> |{' '}
         <Link to="/recommendations">Recommendations</Link> |{' '}
@@ -80,6 +82,7 @@ function App() {
             </div>
           )}
         />
+        <Route path="/executive-dashboard" element={<ExecutiveDashboard />} />
         <Route path="/datasets" element={<DatasetList />} />
         <Route path="/datasets/:name" element={<DatasetDetail />} />
         <Route path="/pages" element={<PagesList />} />

--- a/web/src/pages/ExecutiveDashboard.tsx
+++ b/web/src/pages/ExecutiveDashboard.tsx
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query'
+import React from 'react'
+
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+
+function ExecutiveDashboard() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['summary'],
+    queryFn: async () => {
+      const res = await fetch(`${apiBase}/api/summary`)
+      if (!res.ok) throw new Error('Failed to load summary')
+      return res.json()
+    }
+  })
+
+  if (isLoading) return <p>Loading summary...</p>
+  if (error) return <p>Error loading summary</p>
+
+  const brand = data?.brand_health || {}
+  const metrics = data?.key_metrics || {}
+  const recs = Array.isArray(data?.recommendations) ? data.recommendations : []
+
+  return (
+    <div>
+      <h2>Executive Dashboard</h2>
+      <p>
+        Brand Health: <strong>{brand.raw_score}</strong> {brand.emoji}
+      </p>
+      <ul>
+        <li>Total Pages: {metrics.total_pages}</li>
+        <li>Critical Issues: {metrics.critical_issues}</li>
+        <li>Quick Wins: {metrics.quick_wins}</li>
+        <li>Success Pages: {metrics.success_pages}</li>
+      </ul>
+      <h3>Top Recommendations</h3>
+      <ul>
+        {recs.map((r: string, idx: number) => (
+          <li key={idx}>{r}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default ExecutiveDashboard


### PR DESCRIPTION
## Summary
- expose `/executive-summary` in FastAPI
- proxy `/api/summary` in Express API
- add React ExecutiveDashboard page and navigation
- cover new routes in unit/integration tests
- update Python tests for new endpoint

## Testing
- `pnpm test --filter ./api`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686bfa691a548324b0a08b22713ab4ff