### PR TITLE
Add pnpm registry instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ curl http://localhost:8000/hello
 # {"message":"Hello from FastAPI"}
 ```
 
+### Configure PNPM Registry
+
+To install Node dependencies from the public npm registry, run:
+
+```bash
+pnpm config set registry https://registry.npmjs.org
+```
+
 ## 🎯 Project Overview
 
 This repository contains a complete website audit system that combines:

--- a/setup_codex.sh
+++ b/setup_codex.sh
@@ -10,16 +10,20 @@ python3 -m pip install --upgrade pip
 python3 -m pip install -r local_requirements.txt
 
 # 2. Node.js dependencies for frontend analysis (no build)
+# Use the public npm registry for all installs
+PNPM_REGISTRY="https://registry.npmjs.org"
+pnpm config set registry "$PNPM_REGISTRY"
+
 echo "🟢 Installing Node.js dependencies for web..."
 if [ -f "web/package.json" ]; then
-    (cd web && pnpm install)
+    (cd web && pnpm install --registry "$PNPM_REGISTRY")
 else
     echo "web/package.json not found, skipping web dependencies."
 fi
 
 echo "🟢 Installing Node.js dependencies for api..."
 if [ -f "api/package.json" ]; then
-    (cd api && pnpm install)
+    (cd api && pnpm install --registry "$PNPM_REGISTRY")
 else
     echo "api/package.json not found, skipping api dependencies."
 fi


### PR DESCRIPTION
## Summary
- document how to set the PNPM registry to use npmjs.org
- configure `setup_codex.sh` to install Node packages using registry.npmjs.org

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pnpm -r test --if-present` *(fails: vitest tests in api package)*

------
https://chatgpt.com/codex/tasks/task_b_686c32696ddc83249410cffb953cc934