### PR TITLE
Add metrics API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To install Node dependencies from the public npm registry, run:
 
 ```bash
 pnpm config set registry https://registry.npmjs.org
+pnpm install --registry https://registry.npmjs.org
 ```
 
 ## 🎯 Project Overview

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -191,6 +191,81 @@ app.get('/api/summary', async (_req, res) => {
   }
 });
 
+/**
+ * @openapi
+ * /api/tier-metrics:
+ *   get:
+ *     summary: Tier performance metrics
+ *     responses:
+ *       200:
+ *         description: Array of tier metrics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ */
+app.get('/api/tier-metrics', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/tier-metrics');
+    res.json(response.data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch tier metrics' });
+  }
+});
+
+/**
+ * @openapi
+ * /api/persona-comparison:
+ *   get:
+ *     summary: Persona comparison metrics
+ *     responses:
+ *       200:
+ *         description: Array of persona metrics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ */
+app.get('/api/persona-comparison', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/persona-comparison');
+    res.json(response.data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch persona comparison data' });
+  }
+});
+
+/**
+ * @openapi
+ * /api/full-recommendations:
+ *   get:
+ *     summary: Full list of recommendations
+ *     responses:
+ *       200:
+ *         description: Array of recommendations
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 recommendations:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ */
+app.get('/api/full-recommendations', async (_req, res) => {
+  try {
+    const response = await axios.get('http://localhost:8000/full-recommendations');
+    res.json({ recommendations: response.data });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch recommendations list' });
+  }
+});
+
 app.get('/api/methodology', async (_req, res) => {
   try {
     const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/api/test/integration.test.js
+++ b/api/test/integration.test.js
@@ -50,6 +50,24 @@ describe('Integration Express->FastAPI', () => {
     expect(res.body).toHaveProperty('brand_health');
   });
 
+  it('returns tier metrics', async () => {
+    const res = await request(app).get('/api/tier-metrics');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns persona comparison data', async () => {
+    const res = await request(app).get('/api/persona-comparison');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns full recommendations list', async () => {
+    const res = await request(app).get('/api/full-recommendations');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('length');
+  });
+
   it('lists reports', async () => {
     const res = await request(app).get('/api/reports');
     expect(res.status).toBe(200);

--- a/api/test/routes.test.js
+++ b/api/test/routes.test.js
@@ -63,6 +63,36 @@ describe('GET /api/summary', () => {
   });
 });
 
+describe('GET /api/tier-metrics', () => {
+  it('proxies tier metrics from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ tier: 'tier_1' }] });
+    const res = await request(app).get('/api/tier-metrics');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ tier: 'tier_1' }]);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('GET /api/persona-comparison', () => {
+  it('proxies persona comparison from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ persona: 'P1' }] });
+    const res = await request(app).get('/api/persona-comparison');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ persona: 'P1' }]);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('GET /api/full-recommendations', () => {
+  it('proxies full recommendations from FastAPI', async () => {
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ id: 1 }] });
+    const res = await request(app).get('/api/full-recommendations');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ recommendations: [{ id: 1 }] });
+    vi.restoreAllMocks();
+  });
+});
+
 describe('GET /api/methodology', () => {
   it('returns methodology yaml as json', async () => {
     const res = await request(app).get('/api/methodology');

--- a/audit_tool/tests/test_fastapi_service.py
+++ b/audit_tool/tests/test_fastapi_service.py
@@ -20,3 +20,21 @@ def test_executive_summary_endpoint():
     resp = client.get('/executive-summary')
     assert resp.status_code == 200
     assert 'brand_health' in resp.json()
+
+
+def test_tier_metrics_endpoint():
+    resp = client.get('/tier-metrics')
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+def test_persona_comparison_endpoint():
+    resp = client.get('/persona-comparison')
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+def test_full_recommendations_endpoint():
+    resp = client.get('/full-recommendations')
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/fastapi_service/main.py
+++ b/fastapi_service/main.py
@@ -49,3 +49,37 @@ def get_executive_summary():
     summary = metrics.generate_executive_summary()
     return summary
 
+
+@app.get("/tier-metrics", summary="Tier performance metrics")
+def get_tier_metrics():
+    """Return aggregated performance metrics by content tier"""
+    data_loader = BrandHealthDataLoader()
+    datasets, master_df = data_loader.load_all_data()
+    metrics = BrandHealthMetricsCalculator(master_df, datasets.get("recommendations"))
+    tier_df = metrics.calculate_tier_performance()
+    json_str = tier_df.to_json(orient="records")
+    return Response(content=json_str, media_type="application/json")
+
+
+@app.get("/persona-comparison", summary="Persona comparison metrics")
+def get_persona_comparison():
+    """Return metrics comparing performance across personas"""
+    data_loader = BrandHealthDataLoader()
+    datasets, master_df = data_loader.load_all_data()
+    metrics = BrandHealthMetricsCalculator(master_df, datasets.get("recommendations"))
+    persona_df = metrics.calculate_persona_comparison()
+    json_str = persona_df.to_json(orient="records")
+    return Response(content=json_str, media_type="application/json")
+
+
+@app.get("/full-recommendations", summary="Full list of recommendations")
+def get_full_recommendations():
+    """Return the complete recommendations dataset"""
+    data_loader = BrandHealthDataLoader()
+    datasets, _ = data_loader.load_all_data()
+    rec_df = datasets.get("recommendations")
+    if rec_df is None:
+        return JSONResponse(status_code=404, content={"error": "Recommendations dataset not found"})
+    json_str = rec_df.to_json(orient="records")
+    return Response(content=json_str, media_type="application/json")
+


### PR DESCRIPTION
## Summary
- expose tier performance, persona comparison and recommendation list via FastAPI
- proxy new endpoints through Express API
- document pnpm install registry usage
- add integration/unit tests for new routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pnpm test` *(fails: Integration tests return 500 errors)*

------
https://chatgpt.com/codex/tasks/task_b_686c397c6b188324857f80143894ca04