### PR TITLE
Add FilterContext provider

### DIFF
--- a/web/src/context/FilterContext.tsx
+++ b/web/src/context/FilterContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useState } from 'react'
+
+export interface FilterState {
+  persona: string
+  tier: string
+  scoreRange: [number, number]
+}
+
+interface FilterContextValue extends FilterState {
+  setPersona: (p: string) => void
+  setTier: (t: string) => void
+  setScoreRange: (r: [number, number]) => void
+}
+
+const FilterContext = createContext<FilterContextValue | undefined>(undefined)
+
+export function useFilters() {
+  const ctx = useContext(FilterContext)
+  if (!ctx) throw new Error('useFilters must be used within FilterProvider')
+  return ctx
+}
+
+export function FilterProvider({ children }: { children: React.ReactNode }) {
+  const [persona, setPersona] = useState('')
+  const [tier, setTier] = useState('')
+  const [scoreRange, setScoreRange] = useState<[number, number]>([0, 10])
+
+  const value: FilterContextValue = {
+    persona,
+    tier,
+    scoreRange,
+    setPersona,
+    setTier,
+    setScoreRange
+  }
+
+  return <FilterContext.Provider value={value}>{children}</FilterContext.Provider>
+}
+
+export default FilterContext

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
+import { FilterProvider } from './context/FilterContext'
 
 const queryClient = new QueryClient()
 
@@ -11,7 +12,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <FilterProvider>
+          <App />
+        </FilterProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,

--- a/web/src/pages/PersonaViewer.tsx
+++ b/web/src/pages/PersonaViewer.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import { useFilters } from '../context/FilterContext'
 
 function PersonaViewer() {
   const [personas, setPersonas] = useState<string[]>([])
-  const [selected, setSelected] = useState('')
+  const { persona: selected, setPersona: setSelected } = useFilters()
   const [content, setContent] = useState('')
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- implement `FilterContext` to manage persona, tier and score filters
- wrap `App` with `FilterProvider`
- connect `PersonaViewer` to global filter state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c3c5f849c83248f984d35019d8bd9