### PR TITLE
Implement dashboard improvements

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -51,6 +51,12 @@
   text-align: center;
 }
 
+.score-card progress {
+  width: 100%;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
 .score-card--success {
   color: #28a745;
 }

--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from './DataTable'
 
@@ -22,5 +22,13 @@ describe('DataTable', () => {
     render(<DataTable data={data} columns={columns} />)
     expect(screen.getByText('Alice')).toBeInTheDocument()
     expect(screen.getByText('Bob')).toBeInTheDocument()
+  })
+
+  it('filters rows based on input', () => {
+    render(<DataTable data={data} columns={columns} />)
+    const input = screen.getByPlaceholderText('Filter...')
+    fireEvent.change(input, { target: { value: 'Alice' } })
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.queryByText('Bob')).toBeNull()
   })
 })

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -3,6 +3,7 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  getFilteredRowModel,
   useReactTable,
   type ColumnDef,
   type RowData,
@@ -16,18 +17,34 @@ export interface DataTableProps<T extends RowData> {
 
 export function DataTable<T extends RowData>({ data, columns }: DataTableProps<T>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
+  const [filter, setFilter] = React.useState('')
 
   const table = useReactTable({
     data,
     columns,
-    state: { sorting },
+    state: { sorting, globalFilter: filter },
     onSortingChange: setSorting,
+    onGlobalFilterChange: setFilter,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel()
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _columnId, filterValue: string) => {
+      const val = String(filterValue || '').toLowerCase()
+      return row
+        .getAllCells()
+        .some(cell => String(cell.getValue()).toLowerCase().includes(val))
+    }
   })
 
   return (
-    <table>
+    <div>
+      <input
+        placeholder="Filter..."
+        value={filter}
+        onChange={e => setFilter(e.target.value)}
+        style={{ marginBottom: '0.5rem' }}
+      />
+      <table>
       <thead>
         {table.getHeaderGroups().map(headerGroup => (
           <tr key={headerGroup.id}>
@@ -53,6 +70,7 @@ export function DataTable<T extends RowData>({ data, columns }: DataTableProps<T
         ))}
       </tbody>
     </table>
+    </div>
   )
 }
 

--- a/web/src/components/ScoreCard.test.tsx
+++ b/web/src/components/ScoreCard.test.tsx
@@ -7,4 +7,11 @@ describe('ScoreCard', () => {
     expect(screen.getByText('Test')).toBeInTheDocument()
     expect(screen.getByText('42')).toBeInTheDocument()
   })
+
+  it('shows progress when provided', () => {
+    render(<ScoreCard label="Progress" value="50%" progress={50} />)
+    const progress = screen.getByTestId('progress') as HTMLProgressElement
+    expect(progress).toBeInTheDocument()
+    expect(progress.value).toBe(50)
+  })
 })

--- a/web/src/components/ScoreCard.tsx
+++ b/web/src/components/ScoreCard.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 export interface ScoreCardProps {
   label: string
   value: React.ReactNode
+  /** Optional progress percentage for a progress indicator */
+  progress?: number
   /**
    * Optional visual style variant. Used for performance based
    * colour coding similar to the Streamlit dashboards.
@@ -10,10 +12,13 @@ export interface ScoreCardProps {
   variant?: 'default' | 'success' | 'warning' | 'danger'
 }
 
-export function ScoreCard({ label, value, variant = 'default' }: ScoreCardProps) {
+export function ScoreCard({ label, value, progress, variant = 'default' }: ScoreCardProps) {
   return (
     <div className={`score-card score-card--${variant}`}>
       <strong>{value}</strong>
+      {typeof progress === 'number' && (
+        <progress value={progress} max={100} data-testid="progress" />
+      )}
       <div>{label}</div>
     </div>
   )

--- a/web/src/pages/AuditReports.tsx
+++ b/web/src/pages/AuditReports.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { DataTable, PageContainer } from '../components'
+import { type ColumnDef } from '@tanstack/react-table'
 
 function AuditReports() {
   const { data, isLoading } = useQuery({
@@ -15,17 +17,22 @@ function AuditReports() {
     return <p>Loading...</p>
   }
 
+  const reports: { name: string }[] = (data?.reports || []).map((r: string) => ({ name: r }))
+
+  const columns: ColumnDef<{ name: string }>[] = [
+    {
+      accessorKey: 'name',
+      header: 'Report',
+      cell: info => (
+        <a href={`http://localhost:3000/api/reports/${info.getValue()}`}>{info.getValue()}</a>
+      )
+    }
+  ]
+
   return (
-    <div>
-      <h2>Audit Reports</h2>
-      <ul>
-        {data?.reports.map((r: string) => (
-          <li key={r}>
-            <a href={`http://localhost:3000/api/reports/${r}`}>{r}</a>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <PageContainer title="Audit Reports">
+      <DataTable data={reports} columns={columns} />
+    </PageContainer>
   )
 }
 

--- a/web/src/pages/ExecutiveDashboard.tsx
+++ b/web/src/pages/ExecutiveDashboard.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import React from 'react'
-import { PageContainer, ScoreCard } from '../components'
+import { PageContainer, ScoreCard, ChartCard, PlotlyChart } from '../components'
 
 const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 
@@ -20,6 +20,7 @@ function ExecutiveDashboard() {
   const brand = data?.brand_health || {}
   const metrics = data?.key_metrics || {}
   const recs = Array.isArray(data?.recommendations) ? data.recommendations : []
+  const tierMetrics = data?.score_by_tier || {}
 
   return (
     <PageContainer title="Executive Dashboard">
@@ -28,10 +29,36 @@ function ExecutiveDashboard() {
       </p>
       <div className="filter-bar">
         <ScoreCard label="Total Pages" value={metrics.total_pages} />
-        <ScoreCard label="Critical Issues" value={metrics.critical_issues} />
-        <ScoreCard label="Quick Wins" value={metrics.quick_wins} />
-        <ScoreCard label="Success Pages" value={metrics.success_pages} />
+        <ScoreCard
+          label="Critical Issues"
+          value={metrics.critical_issues}
+          variant={
+            metrics.critical_issues > 10
+              ? 'danger'
+              : metrics.critical_issues > 0
+              ? 'warning'
+              : 'success'
+          }
+        />
+        <ScoreCard
+          label="Quick Wins"
+          value={metrics.quick_wins}
+          variant={metrics.quick_wins > 0 ? 'warning' : 'success'}
+        />
+        <ScoreCard label="Success Pages" value={metrics.success_pages} variant="success" />
       </div>
+
+      <ChartCard title="Average Score by Tier">
+        <PlotlyChart
+          data={[{
+            x: Object.keys(tierMetrics),
+            y: Object.values(tierMetrics),
+            type: 'bar',
+            marker: { color: '#3d4a6b' }
+          }]}
+          layout={{ height: 300 }}
+        />
+      </ChartCard>
       <h3>Top Recommendations</h3>
       <ul>
         {recs.map((r: string, idx: number) => (

--- a/web/src/pages/ImplementationTracking.tsx
+++ b/web/src/pages/ImplementationTracking.tsx
@@ -44,8 +44,20 @@ function ImplementationTracking() {
     <PageContainer title="Implementation Tracking">
       <div className="filter-bar">
         <ScoreCard label="Total Items" value={totalItems} />
-        <ScoreCard label="Completion Rate" value={`${completionRate.toFixed(1)}%`} />
-        <ScoreCard label="Avg Progress" value={`${avgProgress.toFixed(1)}%`} />
+        <ScoreCard
+          label="Completion Rate"
+          value={`${completionRate.toFixed(1)}%`}
+          progress={completionRate}
+          variant={
+            completionRate > 80 ? 'success' : completionRate > 50 ? 'warning' : 'danger'
+          }
+        />
+        <ScoreCard
+          label="Avg Progress"
+          value={`${avgProgress.toFixed(1)}%`}
+          progress={avgProgress}
+          variant={avgProgress > 80 ? 'success' : avgProgress > 50 ? 'warning' : 'danger'}
+        />
         <ScoreCard label="In Progress" value={inProgress} />
       </div>
 

--- a/web/src/pages/OpportunityImpact.tsx
+++ b/web/src/pages/OpportunityImpact.tsx
@@ -69,9 +69,13 @@ function OpportunityImpact() {
       <FilterBar>
         <FilterControls personas={personaOptions} tiers={tierOptions} />
         <ScoreCard label="Total Opps" value={total} />
-        <ScoreCard label="Avg Impact" value={avgImpact.toFixed(1)} />
-        <ScoreCard label="High Impact" value={highImpact} />
-        <ScoreCard label="Low Effort" value={lowEffort} />
+        <ScoreCard
+          label="Avg Impact"
+          value={avgImpact.toFixed(1)}
+          variant={avgImpact >= 7 ? 'success' : avgImpact >= 4 ? 'warning' : 'danger'}
+        />
+        <ScoreCard label="High Impact" value={highImpact} variant="success" />
+        <ScoreCard label="Low Effort" value={lowEffort} variant="success" />
       </FilterBar>
 
       <ExpandableSection title="Impact vs Effort Chart" defaultExpanded>


### PR DESCRIPTION
## Summary
- add optional progress indicator to `ScoreCard`
- color-code metrics and add bar chart on Executive Dashboard
- show progress indicators on Implementation Tracking
- add impact variants on Opportunity Impact
- add global filtering to `DataTable` and test it
- display Audit Reports with `DataTable`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686c485a7ba08324a4d461d9d16bfa6a