### PR TITLE
Add Ant Design dataset list page

### DIFF
--- a/web/src/pages/DatasetList_AntDesign.tsx
+++ b/web/src/pages/DatasetList_AntDesign.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import {
+  List,
+  Typography,
+  Alert,
+  Spin,
+  Layout
+} from 'antd';
+import { mapApiData } from '../utils/mapApiData';
+import '../styles/ant.css';
+
+const { Title } = Typography;
+const { Content } = Layout;
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+function DatasetList_AntDesign() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['datasets'],
+    queryFn: async () => {
+      const res = await fetch(`${apiBase}/api/datasets`);
+      if (!res.ok) throw new Error('Failed to load datasets');
+      return res.json();
+    },
+  });
+
+  const mappedData = data ? mapApiData(data) : null;
+
+  if (isLoading) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content className="content-center">
+            <Spin size="large" />
+            <Title level={2} className="mt-24">Loading datasets...</Title>
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  if (error || !mappedData) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content>
+            <Alert message="Error loading datasets" type="error" showIcon />
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  const datasets: string[] = mappedData.datasets || [];
+
+  return (
+    <div className="ant-design-root">
+      <Layout className="dashboard-layout">
+        <Content>
+          <Title level={1}>Datasets</Title>
+          <List
+            bordered
+            dataSource={datasets}
+            renderItem={(d) => (
+              <List.Item>
+                <Link to={`/datasets/${d}`}>{d}</Link>
+              </List.Item>
+            )}
+          />
+        </Content>
+      </Layout>
+    </div>
+  );
+}
+
+export default DatasetList_AntDesign;

--- a/web/src/utils/mapApiData.ts
+++ b/web/src/utils/mapApiData.ts
@@ -1,0 +1,48 @@
+export interface Opportunity {
+  id: string;
+  title: string;
+  description: string;
+  persona: string;
+  page_id: string;
+  priority_score: number;
+  evidence?: string;
+}
+
+export interface SuccessStory {
+  id: string;
+  page_id: string;
+  description: string;
+  persona: string;
+  url?: string;
+  score: number;
+}
+
+// Generic mapping utility (identity by default)
+export function mapApiData<T>(data: T): T {
+  return data;
+}
+
+// Specific mapping helpers used by Ant pages
+export function mapOpportunity(data: any): Opportunity {
+  return {
+    id: data.id || data.opportunity_id || '',
+    title: data.title || data.name || '',
+    description: data.description || data.desc || '',
+    persona: data.persona || data.persona_name || 'Unknown',
+    page_id: data.page_id || data.page || '',
+    priority_score:
+      data.priority_score !== undefined ? data.priority_score : data.score || 0,
+    evidence: data.evidence || data.evidence_text || '',
+  };
+}
+
+export function mapSuccessStory(data: any): SuccessStory {
+  return {
+    id: data.id || data.story_id || '',
+    page_id: data.page_id || data.page || '',
+    description: data.description || data.story || '',
+    persona: data.persona || data.persona_name || 'Unknown',
+    url: data.url || data.link || '',
+    score: data.score !== undefined ? data.score : data.story_score || 0,
+  };
+}


### PR DESCRIPTION
## Summary
- add Ant Design page `DatasetList_AntDesign.tsx`
- add missing mapping utilities `mapApiData`, `mapOpportunity`, `mapSuccessStory`

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test` *(fails: expected 500 to be 200 in api integration tests)*

------
https://chatgpt.com/codex/tasks/task_b_68736ed3df788324827e49e98e460b20