### PR TITLE
Add Ant Design dataset detail and pages list

### DIFF
--- a/web/src/pages/DatasetDetail_AntDesign.tsx
+++ b/web/src/pages/DatasetDetail_AntDesign.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Typography, Layout, Spin, Alert } from 'antd';
+import { mapApiData } from '../utils/mapApiData';
+import '../styles/ant.css';
+
+const { Title } = Typography;
+const { Content } = Layout;
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+function DatasetDetail_AntDesign() {
+  const { name } = useParams<{ name: string }>();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['dataset-ant', name],
+    queryFn: async () => {
+      const res = await fetch(`${apiBase}/api/datasets/${name}`);
+      if (!res.ok) throw new Error('Failed to load dataset');
+      return res.json();
+    },
+    enabled: !!name,
+  });
+
+  const mapped = data ? (mapApiData(data) as any[]) : null;
+
+  const columns = React.useMemo(() => {
+    if (!Array.isArray(mapped) || mapped.length === 0) return [];
+    return Object.keys(mapped[0]).map((key) => ({
+      title: key,
+      dataIndex: key,
+      key,
+    }));
+  }, [mapped]);
+
+  if (!name) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content>
+            <Alert message="No dataset specified" type="warning" showIcon />
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content className="content-center">
+            <Spin size="large" />
+            <Title level={2} className="mt-24">
+              Loading dataset...
+            </Title>
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  if (error || !mapped) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content>
+            <Alert message="Error loading dataset" type="error" showIcon />
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ant-design-root">
+      <Layout className="dashboard-layout">
+        <Content>
+          <Title level={1}>{`Dataset: ${name}`}</Title>
+          <Table
+            columns={columns}
+            dataSource={mapped}
+            rowKey={(r) => JSON.stringify(r)}
+            scroll={{ x: true }}
+          />
+        </Content>
+      </Layout>
+    </div>
+  );
+}
+
+export default DatasetDetail_AntDesign;

--- a/web/src/pages/PagesList_AntDesign.tsx
+++ b/web/src/pages/PagesList_AntDesign.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query';
+import { Layout, Typography, Spin, Alert } from 'antd';
+import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { mapApiData } from '../utils/mapApiData';
+import '../styles/ant.css';
+
+const { Title } = Typography;
+const { Content } = Layout;
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+function PagesList_AntDesign() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['pages-ant'],
+    queryFn: async () => {
+      const res = await fetch(`${apiBase}/api/pages`);
+      if (!res.ok) throw new Error('Failed to load pages');
+      return res.json();
+    },
+  });
+
+  const mapped = data ? (mapApiData(data) as any) : null;
+  const pages = mapped?.pages || [];
+
+  if (isLoading) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content className="content-center">
+            <Spin size="large" />
+            <Title level={2} className="mt-24">
+              Loading pages...
+            </Title>
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  if (error || !mapped) {
+    return (
+      <div className="ant-design-root">
+        <Layout className="dashboard-layout">
+          <Content>
+            <Alert message="Error loading pages" type="error" showIcon />
+          </Content>
+        </Layout>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ant-design-root">
+      <Layout className="dashboard-layout">
+        <Content>
+          <Title level={1}>Pages Brand Score</Title>
+          <BarChart width={600} height={300} data={pages.slice(0, 10)}>
+            <XAxis dataKey="slug" hide={true} />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="avg_score" fill="#3d4a6b" />
+          </BarChart>
+        </Content>
+      </Layout>
+    </div>
+  );
+}
+
+export default PagesList_AntDesign;

--- a/web/src/utils/mapApiData.ts
+++ b/web/src/utils/mapApiData.ts
@@ -46,3 +46,16 @@ export function mapSuccessStory(data: any): SuccessStory {
     score: data.score !== undefined ? data.score : data.story_score || 0,
   };
 }
+
+export interface PageSummary {
+  slug: string;
+  avgScore: number;
+}
+
+export function mapPageSummary(data: any): PageSummary {
+  return {
+    slug: data.slug || data.page_slug || '',
+    avgScore:
+      data.avg_score !== undefined ? data.avg_score : data.avgScore || 0,
+  };
+}


### PR DESCRIPTION
## Summary
- add Ant Design version of dataset detail page
- add Ant Design version of pages list page
- extend data mapping utility with `mapPageSummary`

## Testing
- `pnpm lint`
- `pnpm format` *(fails: code style issues in repo)*
- `pnpm test` *(fails: integration tests expect running API)*

------
https://chatgpt.com/codex/tasks/task_b_68739b1f8a7c8324b9579c6b655e1640